### PR TITLE
Fix faucet mnemonic

### DIFF
--- a/faucet/config/config.js
+++ b/faucet/config/config.js
@@ -6,7 +6,7 @@ const HOME = ".faucet";
 const mnemonic_path= `${HOME}/mnemonic.txt`
 
 const path = stringToPath("m/44'/118'/0'/0/0")
-const mnemonic = fs.readFileSync(mnemonic_path, "utf8")
+const mnemonic = fs.readFileSync(mnemonic_path, "utf8").trim()
 console.log("======================== faucet mnemonic =========================")
 console.log(mnemonic)
 console.log("==================================================================")


### PR DESCRIPTION
Trim the trailing whitespaces of `mnemonic.txt` file on the config file.
This solves some problems as frequently the file has a final new line