### PR TITLE
Fix faucet prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Then you can try sending a proof for verification with:
 If you want to test it with a valid proof use:
 
 ```
-alignedlayerd tx verification verify --from <your_key_name> --chain-id alignedlayer --node tcp://rpc-node.alignedlayer.com:26657 --fees 20000stake \
+alignedlayerd tx verification verify --from <your_key_name> --chain-id alignedlayer --node tcp://rpc-node.alignedlayer.com:26657 --fees 50000stake \
                                                                   $(cat ./prover_examples/gnark_plonk/example/proof.base64.example) \
                                                                   $(cat ./prover_examples/gnark_plonk/example/public_inputs.base64.example) \
                                                                   $(cat ./prover_examples/gnark_plonk/example/verifying_key.base64.example)

--- a/faucet/config/config.js
+++ b/faucet/config/config.js
@@ -30,7 +30,7 @@ export default {
             sender: {
                 mnemonic,
                 option: {
-                    "prefix": "cosmos",  //address prefix
+                    "prefix": "aligned",  //address prefix
                     "hdPaths": [path],
                 }
             },
@@ -38,7 +38,7 @@ export default {
                 amount: [
                     {
                         denom: "stake",
-                        amount: "10000"
+                        amount: "2000000"
                     },
                 ],
                 fee: {


### PR DESCRIPTION
The faucet config file was not updated with the new prefix.