### PR TITLE
Connecting new nodes to all servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Our public nodes have the following IPs. Please be aware that they are in develo
 91.107.239.79
 116.203.81.174
 88.99.174.203
+128.140.3.188
 ```
 
 ## How It Works

--- a/multi_node_setup.sh
+++ b/multi_node_setup.sh
@@ -110,9 +110,9 @@ for (( i=1; i <= "$#"; i++ )); do
     done
     other_addresses=$(IFS=,; echo "${other_addresses[*]}")
     docker run -v $(pwd)/prod-sim/${!i}:/root/.alignedlayer -it alignedlayerd_i config set config p2p.seeds "$other_addresses" --skip-validate
+    docker run -v $(pwd)/prod-sim/${!i}:/root/.alignedlayer -it alignedlayerd_i config set config rpc.laddr "tcp://0.0.0.0:26657" --skip-validate
 done
 
-docker run -v $(pwd)/prod-sim/$1:/root/.alignedlayer -it alignedlayerd_i config set config rpc.laddr "tcp://0.0.0.0:26657" --skip-validate
 
 echo "Setting up faucet files..."
 mkdir -p prod-sim/faucet/.faucet

--- a/multi_node_setup.sh
+++ b/multi_node_setup.sh
@@ -109,7 +109,7 @@ for (( i=1; i <= "$#"; i++ )); do
         fi
     done
     other_addresses=$(IFS=,; echo "${other_addresses[*]}")
-    docker run -v $(pwd)/prod-sim/${!i}:/root/.alignedlayer -it alignedlayerd_i config set config p2p.seeds "$other_addresses" --skip-validate
+    docker run -v $(pwd)/prod-sim/${!i}:/root/.alignedlayer -it alignedlayerd_i config set config p2p.persistent_peers "$other_addresses" --skip-validate
     docker run -v $(pwd)/prod-sim/${!i}:/root/.alignedlayer -it alignedlayerd_i config set config rpc.laddr "tcp://0.0.0.0:26657" --skip-validate
 done
 

--- a/server_node_setup.sh
+++ b/server_node_setup.sh
@@ -25,12 +25,12 @@ bash ../multi_node_setup.sh ${nodes[@]}
 echo "Setting node addresses in config..."
 for (( i=0; i<4; i++ )); do
     echo $(pwd)
-    seeds=$(docker run -v $(pwd)/prod-sim/${nodes[$i]}:/root/.alignedlayer -it alignedlayerd_i config get config p2p.seeds)
-        for ((j=0; j<4; j++)); do
+    seeds=$(docker run -v $(pwd)/prod-sim/${nodes[$i]}:/root/.alignedlayer -it alignedlayerd_i config get config p2p.persistent_peers)
+        for ((j=0; j<3; j++)); do
         seeds=${seeds//${nodes[$j]}/${nodes_ips[$j]}}
     done
     
-    docker run -v $(pwd)/prod-sim/${nodes[$i]}:/root/.alignedlayer -it alignedlayerd_i config set config p2p.seeds $seeds --skip-validate    
+    docker run -v $(pwd)/prod-sim/${nodes[$i]}:/root/.alignedlayer -it alignedlayerd_i config set config p2p.persistent_peers $seeds --skip-validate    
 done
 
 echo "Sending directories to servers..."

--- a/server_node_setup.sh
+++ b/server_node_setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-nodes=("node0" "node1" "node2")
-nodes_ips=("10.0.0.2" "10.0.0.3" "10.0.0.4")
-servers=("admin@testing-blockchain-1" "admin@testing-blockchain-2" "admin@testing-blockchain-3")
+nodes=("node0" "node1" "node2" "node3")
+nodes_ips=("10.0.0.2" "10.0.0.3" "10.0.0.4" "10.0.0.6")
+servers=("admin@blockchain-1" "admin@blockchain-2" "admin@blockchain-3" "admin@blockchain-4")
 
 rm -rf server-setup
 
@@ -23,10 +23,10 @@ echo "Calling setup script..."
 bash ../multi_node_setup.sh ${nodes[@]}
 
 echo "Setting node addresses in config..."
-for (( i=0; i<3; i++ )); do
+for (( i=0; i<4; i++ )); do
     echo $(pwd)
     seeds=$(docker run -v $(pwd)/prod-sim/${nodes[$i]}:/root/.alignedlayer -it alignedlayerd_i config get config p2p.seeds)
-        for ((j=0; j<3; j++)); do
+        for ((j=0; j<4; j++)); do
         seeds=${seeds//${nodes[$j]}/${nodes_ips[$j]}}
     done
     
@@ -34,7 +34,7 @@ for (( i=0; i<3; i++ )); do
 done
 
 echo "Sending directories to servers..."
-for ((i=0; i<3; i++)); do
+for ((i=0; i<4; i++)); do
     ssh ${servers[i]} "rm -rf /home/admin/.alignedlayer"
     scp -r prod-sim/${nodes[i]} ${servers[i]}:/home/admin/.alignedlayer
 done

--- a/setup_node.sh
+++ b/setup_node.sh
@@ -12,7 +12,10 @@ NODE_HOME=$HOME/.alignedlayer
 CHAIN_BINARY=alignedlayerd
 CHAIN_ID=alignedlayer
 
-: ${PEER_ADDR:="91.107.239.79"}
+: ${PEER_ADDR1:="91.107.239.79"}
+: ${PEER_ADDR2:="116.203.81.174"}
+: ${PEER_ADDR3:="88.99.174.203"}
+: ${PEER_ADDR4:="128.140.3.188"}
 : ${MINIMUM_GAS_PRICES="0.25stake"}
 
 ignite chain build
@@ -21,18 +24,31 @@ $CHAIN_BINARY comet unsafe-reset-all
 $CHAIN_BINARY init $MONIKER \
     --chain-id $CHAIN_ID --overwrite
 
-curl $PEER_ADDR:26657/genesis \
+curl $PEER_ADDR1:26657/genesis \
     | jq '.result.genesis' \
     > $NODE_HOME/config/genesis.json
 
-PEER_IR=$(
-    curl -s $PEER_ADDR:26657/status \
+PEER_IR1=$(
+    curl -s $PEER_ADDR1:26657/status \
     | jq -r '.result.node_info.id'
 )
 
-$CHAIN_BINARY config set config p2p.seeds "$PEER_IR@$PEER_ADDR:26656" \
-    --skip-validate
-$CHAIN_BINARY config set config p2p.persistent_peers "$PEER_IR@$PEER_ADDR:26656" \
+PEER_IR2=$(
+    curl -s $PEER_ADDR2:26657/status \
+    | jq -r '.result.node_info.id'
+)
+
+PEER_IR3=$(
+    curl -s $PEER_ADDR3:26657/status \
+    | jq -r '.result.node_info.id'
+)
+
+PEER_IR4=$(
+    curl -s $PEER_ADDR4:26657/status \
+    | jq -r '.result.node_info.id'
+)
+
+$CHAIN_BINARY config set config p2p.persistent_peers "$PEER_IR1@$PEER_ADDR1:26656,$PEER_IR2@$PEER_ADDR2:26656,$PEER_IR3@$PEER_ADDR3:26656,$PEER_IR4@$PEER_ADDR4:26656" \
     --skip-validate
 $CHAIN_BINARY config set app minimum-gas-prices $MINIMUM_GAS_PRICES \
     --skip-validate


### PR DESCRIPTION
Right now the `setup_node` script only connects to `node0`. We change the setup scripts for the nodes and the servers so that new nodes can connect to all servers, making the connection more stable.