### PR TITLE
Fix faucet IPs recognition

### DIFF
--- a/faucet/faucet.js
+++ b/faucet/faucet.js
@@ -14,7 +14,7 @@ console.log("loaded config: ", conf)
 const mutex = withTimeout(new Mutex(), 10000);
 
 const app = express()
-
+app.enable("trust proxy")
 app.set("view engine", "ejs");
 
 const checker = new FrequencyChecker(conf)


### PR DESCRIPTION
Because we are running the faucet behind a reverse proxy, the faucet wasn't getting the correct IP, instead, it was getting localhost.