### PR TITLE
Reduce faucet petition limit

### DIFF
--- a/faucet/config/config.js
+++ b/faucet/config/config.js
@@ -53,10 +53,10 @@ export default {
             },
             limit: {
                 // how many times each wallet address is allowed in a window(24h)
-                address: 1000, 
+                address: 10, 
                 // how many times each ip is allowed in a window(24h),
                 // if you use proxy, double check if the req.ip is return client's ip.
-                ip: 1000
+                ip: 10
             }
         },
     ]    


### PR DESCRIPTION
The previous limit was 1000 petitions per day per ip/address. We needed to reduce it because it was emptying too fast.