### PR TITLE
Fix setup validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ make build-linux
 Create some keys:
 
 ```sh
-alignedlayerd keys add <your_key_name> --node tcp://91.107.239.79:26657
+alignedlayerd keys add <your_key_name>
 ```
 
 After adding the keys you will get an address, use it in the [faucet](https://faucet.alignedlayer.com/) to get more gas for paying fees.

--- a/setup_validator.sh
+++ b/setup_validator.sh
@@ -33,4 +33,4 @@ EOF
 
 $CHAIN_BINARY tx staking create-validator $NODE_HOME/config/validator.json \
 	--from $VALIDATOR --chain-id $CHAIN_ID \
-	--node tcp://$PEER_ADDR:26657 --fees $FEES
+	--node tcp://$(echo $PEER_ADDR | cut -d, -f1):26657 --fees $FEES


### PR DESCRIPTION
The script uses the same envvar PEER_ADDR as setup_node.sh, but it expected a single address while the second expect a list of addresses. I change the script so whether the envvar is a list or a single address, it always took the first one.