### PR TITLE
Change server files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,3 @@ clean-ffi:
 
 clean:
 	rm -rf ~/.alignedlayer
-	rm -f $$(which alignedlayerd)

--- a/server_node_setup.sh
+++ b/server_node_setup.sh
@@ -27,8 +27,8 @@ rm -rf server-setup
 
 echo "Downloading binaries into servers..."
 for server in "${servers[@]}"; do
-    ssh $server "rm -rf /home/admin/alignedlayerd"
-    ssh $server "curl -L -s --output alignedlayerd https://github.com/yetanotherco/aligned_layer_tendermint/releases/download/$2/alignedlayerd && chmod +x alignedlayerd"
+    ssh $server "sudo rm /usr/bin/alignedlayerd"
+    ssh $server "cd /usr/bin && sudo curl -L --output alignedlayerd https://github.com/yetanotherco/aligned_layer_tendermint/releases/download/$2/alignedlayerd && sudo chmod +x alignedlayerd"
 done
 
 mkdir -p server-setup

--- a/server_node_setup.sh
+++ b/server_node_setup.sh
@@ -53,6 +53,8 @@ echo "Sending directories to servers..."
 for i in "${!servers[@]}"; do  
     ssh ${servers[$i]} "rm -rf /home/admin/.alignedlayer"
     scp -r "prod-sim/${nodes[$i]}" "${servers[$i]}:/home/admin/.alignedlayer"
+    ssh ${servers[$i]} "rm -rf /home/admin/keys"
+    ssh ${servers[$i]} "mv /home/admin/.alignedlayer/keys /home/admin/keys"
 done
 
 


### PR DESCRIPTION
The old binary was stored on `$HOME`, this was unintuitive. Now the binary is stored on `/usr/bin` which is inside the `$PATH`. The keys folder is now moved to `$HOME` so that it is not accidentally erased when calling `make clean`.